### PR TITLE
chore: Update tauri.conf.json to new v2

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,11 +11,10 @@ RUN apt-get update
 
 # Install packages for Cypress
 RUN export DEBIAN_FRONTEND=noninteractive \
-      && apt-get -y install --no-install-recommends libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+      && apt-get -y install --no-install-recommends libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libxtst6 xauth xvfb
 
 # Install packages for Tauri
-RUN export DEBIAN_FRONTEND=noninteractive \
-      && apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
+RUN apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
 
 # Install Firefox
 # RUN apt-get install -y firefox-esr
@@ -27,4 +26,4 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 # RUN apt-get install -y microsoft-edge-stable
 
 # Clean up
-RUN apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+# RUN apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,17 +1,21 @@
-FROM mcr.microsoft.com/devcontainers/base:bullseye
+FROM ubuntu:24.04
 
-# Add browser apt repositories
-RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
+# # Add browser apt repositories
+# RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
+#     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
 
-RUN wget -q -O - https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge.list'
+# RUN wget -q -O - https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+#     && sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge.list'
 
 RUN apt-get update
 
 # Install packages for Cypress
 RUN export DEBIAN_FRONTEND=noninteractive \
-     && apt-get -y install --no-install-recommends libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+      && apt-get -y install --no-install-recommends libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+
+# Install packages for Tauri
+RUN export DEBIAN_FRONTEND=noninteractive \
+      && apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
 
 # Install Firefox
 # RUN apt-get install -y firefox-esr

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -87,7 +87,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
 
       - name: 📰 Cache Rust dependencies (mac and ubuntu)
         uses: actions/cache@v4

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -65,17 +65,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: 🏪 Cache Node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            node_modules
-            "**/node_modules"
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
       - name: 🛠️ Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -84,35 +73,12 @@ jobs:
 
       - name: 🔨 Install Dependencies
         run: npm ci
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
 
       - name: 🏗️ Build App
         run: npm run build
 
       - name: ✅ Run Unit Tests
         run: npm run test
-
-      - name: 🏪 Cache Cypress Binary (mac and ubuntu)
-        id: cache-cypress-binary
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/Cypress
-          key: ${{ runner.os }}-binary-${{ hashFiles('package-lock.json') }}
-        if: matrix.os != 'windows-latest'
-
-      - name: 🏪 Cache Cypress Binary (windows)
-        id: cache-cypress-binary-windows
-        uses: actions/cache@v4
-        with:
-          path: |
-            C:\Users\runneradmin\AppData\Local\Cypress\Cache
-          key: ${{ runner.os }}-binary-${{ hashFiles('package-lock.json') }}
-        if: matrix.os == 'windows-latest'
-
-      - name: 🧪 Install Cypress
-        run: npm run cy:install
-        if: steps.cache-cypress-binary.outputs.cache-hit != 'true' || steps.cache-cypress-binary-windows.outputs.cache-hit != 'true'
 
       - name: ✅ Run Cypress Tests
         run: npm run test:e2e:ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -2611,6 +2611,7 @@
       "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.0.1.tgz",
       "integrity": "sha512-fCheW0iWYWUtFV3ui3HlMhk3ZJpAQ5KJr7B7UmfhDzBSy1h5JBdrCtvDwy+3AcPN+Fg5Ey3JciF8zEP8eBx+vQ==",
       "dev": true,
+      "license": "Apache-2.0 OR MIT",
       "bin": {
         "tauri": "tauri.js"
       },
@@ -2642,6 +2643,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -2658,6 +2660,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -2674,6 +2677,7 @@
         "arm"
       ],
       "dev": true,
+      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2690,6 +2694,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2706,6 +2711,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2722,6 +2728,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2738,6 +2745,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2754,6 +2762,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2770,6 +2779,7 @@
         "ia32"
       ],
       "dev": true,
+      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2786,6 +2796,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "win32"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,57 +1,44 @@
 {
-  "$schema": "../node_modules/@tauri-apps/cli/schema.json",
+  "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
+  "identifier": "halceyon.linear-clock",
   "build": {
     "beforeBuildCommand": "npm run build",
     "beforeDevCommand": "npm run dev",
-    "devPath": "http://localhost:9080",
-    "distDir": "../dist"
+    "devUrl": "http://localhost:9080",
+    "frontendDist": "../dist"
   },
-  "package": {
-    "productName": "linear-clock",
-    "version": "0.1.0"
+  "bundle": {
+    "active": true,
+    "category": "DeveloperTool",
+    "copyright": "",
+    "externalBin": [],
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns",
+      "icons/icon.ico"
+    ],
+    "longDescription": "",
+    "macOS": {
+      "entitlements": null,
+      "exceptionDomain": "",
+      "frameworks": [],
+      "providerShortName": null,
+      "signingIdentity": null
+    },
+    "resources": [],
+    "shortDescription": "",
+    "targets": "all",
+    "windows": {
+      "certificateThumbprint": null,
+      "digestAlgorithm": "sha256",
+      "timestampUrl": ""
+    }
   },
-  "tauri": {
-    "allowlist": {
-      "all": false
-    },
-    "bundle": {
-      "active": true,
-      "category": "DeveloperTool",
-      "copyright": "",
-      "deb": {
-        "depends": []
-      },
-      "externalBin": [],
-      "icon": [
-        "icons/32x32.png",
-        "icons/128x128.png",
-        "icons/128x128@2x.png",
-        "icons/icon.icns",
-        "icons/icon.ico"
-      ],
-      "identifier": "halceyon.linear-clock",
-      "longDescription": "",
-      "macOS": {
-        "entitlements": null,
-        "exceptionDomain": "",
-        "frameworks": [],
-        "providerShortName": null,
-        "signingIdentity": null
-      },
-      "resources": [],
-      "shortDescription": "",
-      "targets": "all",
-      "windows": {
-        "certificateThumbprint": null,
-        "digestAlgorithm": "sha256",
-        "timestampUrl": ""
-      }
-    },
+  "app": {
     "security": {
       "csp": null
-    },
-    "updater": {
-      "active": false
     },
     "windows": [
       {


### PR DESCRIPTION
refactor: Remove caching of Node modules and Cypress binary

The commit removes the caching of Node modules and Cypress binary in the build-and-release workflow. This change was made to simplify the workflow and improve consistency across different operating systems.

Fixes #455